### PR TITLE
 Fix and run CT on GitHub Actions

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,5 +1,9 @@
 name: "Erlang CI"
-on: ["push", "pull_request"]
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
 
 jobs:
   build:
@@ -22,3 +26,12 @@ jobs:
         make eunit
         dbus-run-session --config-file=demo/test/session.conf -- make -C demo eunit
 
+    - name: Run CT
+      run: |
+        make ct
+    - name: Upload ct logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: ct_logs
+        path: logs

--- a/test/dbus_client_SUITE.erl
+++ b/test/dbus_client_SUITE.erl
@@ -80,6 +80,7 @@ init_per_group(connect_tcp_anonymous, Config) ->
 init_per_group(connect_unix_anonymous, Config) ->
     start_dbus(Config, ?dbus_session_unix_anonymous);
 init_per_group(connect_unix_external, Config) ->
+    application:set_env(dbus, external_cookie, system_user),
     start_dbus(Config, ?dbus_session_unix_external);
 init_per_group(_Name, Config) ->
     Config0 = start_dbus(Config, ?dbus_session_unix_external),

--- a/test/dbus_client_SUITE_data/session_tcp_anonymous.conf
+++ b/test/dbus_client_SUITE_data/session_tcp_anonymous.conf
@@ -7,7 +7,8 @@
   <listen>tcp:host=localhost,bind=*,port=55555,family=ipv4</listen>
   <auth>ANONYMOUS</auth>
   <allow_anonymous/>
-  
+  <apparmor mode="disabled"/>
+
   <standard_session_servicedirs />
 
   <policy context="default">


### PR DESCRIPTION
- Run github action on PRs and pushes on master branch only
- Run and upload CT logs so that issues can be identified
- Run session_tcp_anonymous tests with apparmor mode disabled - this is
required to run on Ubuntu
- For connect_unix_external tests, use actual user id that is being used
to run - on github actions, user id is not 1000, which seems to be the
hardcoded value by default